### PR TITLE
fix npm run lint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
         "jscs": "^2.2.1"
     },
     "scripts": {
-         "lint": "jscs *.js"
+         "lint": "jscs ."
     }
 }


### PR DESCRIPTION
windows: `Error: Path *.js was not found.`
